### PR TITLE
Add parsing of EPOC+ V1.1 Gyrometer Data And Groundwork for Other Headset Translations

### DIFF
--- a/csharp/MotionLogger/Program.cs
+++ b/csharp/MotionLogger/Program.cs
@@ -13,8 +13,26 @@ namespace MotionLogger
     {
         const string OutFilePath = @"MotionLogger.csv";
         const string licenseID = ""; // Do not need license id when subscribe motion
+        const int noiseThreshold = 20;
+        const int baselineThreshold = 1000;
+
+        private static GyrometerType currentGyroType = GyrometerType.Unknown;
+        private static float rollingSum = 0;
+        private static int gyroXIndex = -1;
+        private static int gyroYIndex = -1;
+        private static int gyroZIndex = -1;
+        private static int gyroWIndex = -1;
 
         private static FileStream OutFileStream;
+
+        // Reference: https://emotiv.gitbook.io/epoc-user-manual/introduction-1/technical_specifications
+        enum GyrometerType
+        {
+            G, // +- 8g: Epoc v1.0. Uses GYROX, GYROY.
+            DPS, // +- 500 d/s: Epoc+ v1.1. Uses GYROX, GYROY, GYROZ.
+            Quaternion, // 4D Quaternions: Epoc X, Epoc+ v1.1A. Uses Q0, Q1, Q2, Q3.
+            Unknown, // Default case of unknown Gyrometer
+        }
 
         static void Main(string[] args)
         {
@@ -27,6 +45,7 @@ namespace MotionLogger
                 File.Delete(OutFilePath);
             }
             OutFileStream = new FileStream(OutFilePath, FileMode.Append, FileAccess.Write);
+            rollingSum = 0;
 
 
             DataStreamExample dse = new DataStreamExample();
@@ -57,9 +76,38 @@ namespace MotionLogger
                 {
                     // print header
                     ArrayList header = e[key].ToObject<ArrayList>();
+
                     //add timeStamp to header
                     header.Insert(0, "Timestamp");
                     WriteDataToFile(header);
+
+                    // Determine what type of gyrometer we have available
+                    if (header.Contains("GYROX") && header.Contains("GYROY") && header.Contains("GYROZ"))
+                    {
+                        Console.WriteLine("Detected Epoc+ v1.1 model headset, which uses dps.");
+                        currentGyroType = GyrometerType.DPS;
+                        gyroXIndex = header.IndexOf("GYROX");
+                        gyroYIndex = header.IndexOf("GYROY");
+                        gyroZIndex = header.IndexOf("GYROZ");
+                    } else if (header.Contains("GYROX") && header.Contains("GYROY")) {
+                        Console.WriteLine("Detected Epoc v1.0 model headset, which uses g.");
+                        currentGyroType = GyrometerType.G;
+                        gyroXIndex = header.IndexOf("GYROX");
+                        gyroYIndex = header.IndexOf("GYROY");
+                    } else if (header.Contains("Q0") && header.Contains("Q1") && header.Contains("Q2") && header.Contains("Q3"))
+                    {
+                        Console.WriteLine("Detected Epoc X or Epoc+ v1.1A model headset, which uses quaternions.");
+                        currentGyroType = GyrometerType.Quaternion;
+                        gyroXIndex = header.IndexOf("Q0");
+                        gyroYIndex = header.IndexOf("Q1");
+                        gyroZIndex = header.IndexOf("Q2");
+                        gyroWIndex = header.IndexOf("Q3");
+                    }
+                    else
+                    {
+                        Console.WriteLine("This is a type of headset we've not yet seen before. See the contained headers: " + header.ToString());
+                        currentGyroType = GyrometerType.Unknown;
+                    }
                 }
             }
         }
@@ -86,7 +134,12 @@ namespace MotionLogger
         private static void OnMotionDataReceived(object sender, ArrayList motData)
         {
             WriteDataToFile(motData);
+            
         }
 
+        private static float ConvertDegreesPerSecond(float dps)
+        {
+            return 0.0f;
+        }
     }
 }

--- a/csharp/MotionLogger/Program.cs
+++ b/csharp/MotionLogger/Program.cs
@@ -159,7 +159,11 @@ namespace MotionLogger
 
         private static void OnMotionDataReceived(object sender, ArrayList motData)
         {
-            
+            double action1Value = 0f;
+            double action2Value = 0f;
+            double action3Value = 0f;
+            double action4Value = 0f;
+
             switch (currentGyroType)
             {
                 case GyrometerType.DPS:
@@ -186,16 +190,16 @@ namespace MotionLogger
                     // For testing, let's just have this be an on/off. We can figure out scaling later, but for now let's use a fixed movement speed when this action is on
 
                     // yAxisActionValue is negative when the user is looking down (Action1).
-                    float action1Value = yAxisActionValue >= 0 ? 0f : 1f;
+                    action1Value = yAxisActionValue >= 0 ? 0f : 1f;
 
                     // yAxisActionValue is positive when the user is looking up (Action2)
-                    float action2Value = yAxisActionValue < 0 ? 0f : 1f;
+                    action2Value = yAxisActionValue < 0 ? 0f : 1f;
 
                     // zAxisActionValue is negative when the user is tilting their head left (Action3)
-                    float action3Value = zAxisActionValue >= 0 ? 0f : 1f;
+                    action3Value = zAxisActionValue >= 0 ? 0f : 1f;
 
                     // zActionActionValue is positive when the user is tilting their head right (Action4)
-                    float action4Value = zAxisActionValue < 0 ? 0f : 1f;
+                    action4Value = zAxisActionValue < 0 ? 0f : 1f;
 
                     Console.WriteLine($"Action 1: {action1Value}. Action 2: {action2Value}. Action 3: {action3Value}. Action 4: {action4Value}.");
 
@@ -205,8 +209,35 @@ namespace MotionLogger
                     motData.Add(action4Value);
 
                     break;
+                case GyrometerType.Quaternion: // Note: data cleansing/validation not yet performed due to lack of headset, some of these values may be incorrectly assigned, but the logic should remain ~the same
+                    Quaternion q = new Quaternion
+                    {
+                        x = (double) motData[gyroXIndex],
+                        y = (double)motData[gyroYIndex],
+                        z = (double)motData[gyroZIndex],
+                        w = (double)motData[gyroWIndex],
+
+                    };
+                    EulerAngles ea = ConvertQuaternions(q);
+
+                    // pitch is negative when the user is looking down (Action1).
+                    action1Value = ea.pitch >= 0 ? 0f : ea.pitch;
+
+                    // pitch is positive when the user is looking up (Action2)
+                    action2Value = ea.pitch < 0 ? 0f : ea.pitch;
+
+                    // roll is negative when the user is tilting their head left (Action3)
+                    action3Value = ea.roll >= 0 ? 0f : ea.roll;
+
+                    // roll is positive when the user is tilting their head right (Action4)
+                    action4Value = ea.roll < 0 ? 0f : ea.roll;
+
+                    // yaw would be the equivilent of shaking your head 'no' for left and right, which could provide more inputs, but is less reliable
+
+                    Console.WriteLine($"Action 1: {action1Value}. Action 2: {action2Value}. Action 3: {action3Value}. Action 4: {action4Value}.");
+
+                    break;
                 case GyrometerType.G:
-                case GyrometerType.Quaternion:
                 case GyrometerType.Unknown:
                     Console.WriteLine($"Processing for {currentGyroType.ToString()} is not supported [ yet :) ]");
                     break;


### PR DESCRIPTION
With this, the resulting action statuses should be logged to the console (after MOT Data Received) and should also be stored in the resulting .csv. Only Epoc+ V1.1 (d/s) headsets' data was validated. While a tentative Epoc X / Epoc+V1.1A implementation is included, it's data has not been validated, so the interpretation of some values/actions are likely incorrect. Fixing this should be a matter of index shifting once real data is received.